### PR TITLE
bug: fixed typo in keystone url of scs-community-platform

### DIFF
--- a/charts/cloudprofiles/Chart.yaml
+++ b/charts/cloudprofiles/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3

--- a/charts/cloudprofiles/charts/scs-community-platform/values.yaml
+++ b/charts/cloudprofiles/charts/scs-community-platform/values.yaml
@@ -45,7 +45,7 @@ providerConfig:
   useOctavia: true
   keystoneURLs:
   - region: RegionOne
-    url: https://api.gx-scs-sovereignit.cloud:5000
+    url: https://api.gx-scs.sovereignit.cloud:5000
   constraints:
     floatingPools:
     - name: ext01


### PR DESCRIPTION
Kind of fatal if you have the wrong keystone url. Tried the profile today and noticed the wrong url.

Signed-off-by: Tim Beermann <beermann@osism.tech>
