### PR TITLE
kube apiserver

### DIFF
--- a/charts/garden-kube-apiserver/Chart.yaml
+++ b/charts/garden-kube-apiserver/Chart.yaml
@@ -15,4 +15,4 @@
 apiVersion: v1
 description: Helm chart for garden
 name: garden-kube-apiserver
-version: 3.27.7
+version: v1.24.3

--- a/charts/garden-kube-apiserver/Chart.yaml
+++ b/charts/garden-kube-apiserver/Chart.yaml
@@ -15,4 +15,4 @@
 apiVersion: v1
 description: Helm chart for garden
 name: garden-kube-apiserver
-version: 3.27.0
+version: 3.27.7

--- a/charts/garden-kube-apiserver/templates/deployment-kube-apiserver.yaml
+++ b/charts/garden-kube-apiserver/templates/deployment-kube-apiserver.yaml
@@ -96,7 +96,6 @@ spec:
 {{ if .Values.etcd.events.endpoints }}
 {{ end }}
         - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
-        - --insecure-port=0
 {{ if .Values.apiServer.oidcIssuerURL }}
         - --oidc-issuer-url={{ .Values.apiServer.oidcIssuerURL }}
         - --oidc-client-id=kube-kubectl
@@ -115,11 +114,13 @@ spec:
         - --requestheader-username-headers=X-Remote-User
         - --secure-port=443
         - --service-cluster-ip-range=100.64.0.0/13
-        - --service-account-key-file=/srv/kubernetes/service-account-key/service_account.key
         - --tls-cert-file=/srv/kubernetes/apiserver/tls.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
         - --v=2
+        - --service-account-issuer=https://kubernetes.default.svc
+        - --service-account-signing-key-file=/srv/kubernetes/service-account-key/service_account.key
+        - --service-account-key-file=/srv/kubernetes/service-account-key/service_account.key
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -199,8 +200,8 @@ spec:
           failureThreshold: 2
           httpGet:
             path: /healthz
-            port: 10252
-            scheme: HTTP
+            port: 10257
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1

--- a/charts/garden-kube-apiserver/values.yaml
+++ b/charts/garden-kube-apiserver/values.yaml
@@ -15,8 +15,8 @@
 namespace: xxx
 serviceName: garden-kube-apiserver
 images:
-  apiserver: k8s.gcr.io/kube-apiserver:v1.19.15
-  controllermanager: k8s.gcr.io/kube-controller-manager:v1.19.15
+  apiserver: k8s.gcr.io/kube-apiserver:v1.24.3
+  controllermanager: k8s.gcr.io/kube-controller-manager:v1.24.3
 
 replicas: 3
 apiServer:


### PR DESCRIPTION
- Slight modifications to kube-apiserver to use current v1.24 image
- Set garden-kube-apiserver version to v1.24.3
