### PR TITLE
kube apiserver

### DIFF
--- a/hack/helmchart-import/import-gardener-charts.py
+++ b/hack/helmchart-import/import-gardener-charts.py
@@ -48,11 +48,6 @@ config = [
                 "chart_name": "garden-etcd",
                 "update_tag": False
             },
-            {
-                "src": "components/kube-apiserver/chart",
-                "chart_name": "garden-kube-apiserver",
-                "update_tag": False
-            },
         ],
     },
     {


### PR DESCRIPTION
- Slight modifications to kube-apiserver to use current v1.24 image
- Set garden-kube-apiserver version to v1.24.3
- disable import of gardener-apiserver via python-import script
